### PR TITLE
Front end render

### DIFF
--- a/lib/animate/animation.js
+++ b/lib/animate/animation.js
@@ -22,7 +22,7 @@ const clone = require('lodash/clone');
 const FFBase = require('../core/base');
 const Utils = require('../utils/utils');
 const DateUtil = require('../utils/date');
-const TWEEN = require('@tweenjs/tween.js');
+const TWEEN = require('@tweenjs/tween.js/dist/tween.umd');
 
 class FFAnimation extends FFBase {
   constructor(conf = { time: 0.7, delay: 0, ease: 'Linear.None' }) {

--- a/lib/animate/tween.js
+++ b/lib/animate/tween.js
@@ -13,7 +13,7 @@
 const get = require('lodash/get');
 const clone = require('lodash/clone');
 const DateUtil = require('../utils/date');
-const TWEEN = require('@tweenjs/tween.js');
+const TWEEN = require('@tweenjs/tween.js/dist/tween.umd');
 
 const FFTween = {
   /**

--- a/lib/center/center.js
+++ b/lib/center/center.js
@@ -19,13 +19,15 @@
  * @object
  */
 
+try {
+  const FFmpegUtil = require('../utils/ffmpeg');
+} catch (err) {}
 const util = require('util');
 const EventEmitter = require('eventemitter3');
 const TaskQueue = require('./task');
 const Progress = require('./progress');
 const Utils = require('../utils/utils');
 const FFLogger = require('../utils/logger');
-const FFmpegUtil = require('../utils/ffmpeg');
 
 const FFCreatorCenter = {
   cursor: 0,

--- a/lib/conf/conf.js
+++ b/lib/conf/conf.js
@@ -12,7 +12,6 @@
  * @object
  */
 const path = require('path');
-const mtempy = require('mtempy');
 const Utils = require('../utils/utils');
 
 class Conf {
@@ -41,12 +40,17 @@ class Conf {
     this.copyFromMultipleVal(conf, 'height', 'h', 450);
     this.copyFromMultipleVal(conf, 'parallel', 'frames', 3);
     this.copyFromMultipleVal(conf, 'render', 'renderer', 'canvas');
-    this.copyFromMultipleVal(conf, 'outputDir', 'dir', path.join('./'));
-    this.copyFromMultipleVal(conf, 'cacheDir', 'cacheDir', mtempy.directory());
-    this.copyFromMultipleVal(conf, 'output', 'out', path.join('./', `${this.conf.pathId}.mp4`));
     this.copyFromMultipleVal(conf, 'highWaterMark', 'size', '1mb');
     this.copyFromMultipleVal(conf, 'normalizeAudio', 'norAudio', false);
     this.copyFromMultipleVal(conf, 'clarity', 'renderClarity', 'medium');
+
+    // for backend render
+    if (!conf.canvas) {
+      const mtempy = require('mtempy');
+      this.copyFromMultipleVal(conf, 'outputDir', 'dir', path.join('./'));
+      this.copyFromMultipleVal(conf, 'cacheDir', 'cacheDir', mtempy.directory());
+      this.copyFromMultipleVal(conf, 'output', 'out', path.join('./', `${this.conf.pathId}.mp4`));
+    }
   }
 
   /**

--- a/lib/core/renderer.js
+++ b/lib/core/renderer.js
@@ -22,23 +22,57 @@
  */
 
 // const GLReset = require("gl-reset");
+
+try {
+  const FS = require('../utils/fs');
+  const Perf = require('../utils/perf');
+  const Synthesis = require('./synthesis');
+  const FFStream = require('../utils/stream');
+} catch (err) {}
+
 const { gl } = require('inkpaint');
 const forEach = require('lodash/forEach');
-const FS = require('../utils/fs');
 const GLUtil = require('../utils/gl');
-const Perf = require('../utils/perf');
-const FFBase = require('../core/base');
-const Synthesis = require('./synthesis');
-const FFStream = require('../utils/stream');
 const FFLogger = require('../utils/logger');
 const CanvasUtil = require('../utils/canvas');
 const Timeline = require('../timeline/timeline');
+const FFBase = require('../core/base');
+const TWEEN = require('@tweenjs/tween.js/dist/tween.umd');
 
 class Renderer extends FFBase {
   constructor({ creator }) {
     super({ type: 'renderer' });
     this.stop = false;
     this.parent = creator;
+  }
+
+  async jumpTo(timeInMs) {
+    await this.timeline.jumpTo(timeInMs);
+    this.renderFrame();
+  }
+
+  async play(playRate=1.0, callback) {
+    this.playRate = playRate;
+    if (!this.timer) {
+      // todo: 其实这个time根本没关系，应该换成 window.requestAnimationFrame(draw)
+      const time = 1000 / this.timeline.fps;
+      this.timer = setInterval(() => {
+        this.renderFrame(frameData => {
+          if (frameData === null) this.pause(); // at end
+        });
+        callback && callback(TWEEN.now());
+      }, time)
+    }
+  }
+
+  async pause() {
+    this.playRate = 0;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    await this.timeline.pause();
+    this.snapshotToBuffer();
   }
 
   /**
@@ -50,13 +84,20 @@ class Renderer extends FFBase {
     this.emit({ type: 'start' });
     await this.preProcessing();
 
-    Perf.start();
+    const creator = this.getCreator();
+    if (!creator.conf.getVal('canvas')) {
+      Perf.start();
+      this.configCache();
+      this.createStream();
+      this.createSynthesis();
+    }
+
     this.createGL();
     this.transBindGL();
-    this.configCache();
-    this.createStream();
     this.createTimeline();
-    this.createSynthesis();
+
+    this.playRate = 0;
+    this.renderFrame();
   }
 
   /**
@@ -159,28 +200,27 @@ class Renderer extends FFBase {
       return null;
     }
 
-    const { type, progress, sceneStart, sceneOver, isLast, scenesIndex } = frameData;
+    const { type, progress, sceneStart, sceneOver, isLast, scenesIndex, frame} = frameData;
     const creator = this.getCreator();
     let scene, data;
 
-    // Various scene states
-    // scene frameData start event
-    if (sceneStart) {
-      const cindex = frameData.getLastSceneIndex();
-      scene = this.getSceneByIndex(cindex);
-      creator.addDisplayChild(scene);
-      scene.start();
-    }
+    // console.log('renderer.renderFrame', {frame, scenesIndex});
 
-    // scene frame end event
-    if (sceneOver && !isLast) {
-      const pindex = frameData.getPrevSceneIndex();
-      scene = this.getSceneByIndex(pindex);
-      creator.removeDisplayChild(scene);
+    const scenes = this.getScenes();
+    for (let i = 0; i < scenes.length; i++) {
+      scene = scenes[i];
+      const showing = scene.showing();
+      if (scenesIndex.includes(i)) {
+        //should shown
+        if (!showing) scene.start();
+      } else {
+        //should hidden
+        if (showing) scene.end();
+      }
     }
 
     FFLogger.info({ pos: 'renderFrame', msg: `current frame - ${timeline.frame}` });
-    timeline.nextFrame();
+    timeline.nextFrame(this.playRate);
 
     // Rendering logic part
     if (type === 'normal') {
@@ -287,16 +327,17 @@ class Renderer extends FFBase {
    * @private
    */
   removeCacheFiles() {
-    if (this.rootConf('debug')) return;
+    // canvas: front-end render has no cache
+    if (this.rootConf('debug') || this.rootConf('canvas')) return;
     const dir = this.rootConf('detailedCacheDir');
     FS.rmDir(dir);
   }
 
   destroy() {
     // GLReset(this.gl)();
-    this.stream.destroy();
+    this.stream?.destroy();
     this.timeline.destroy();
-    this.synthesis.destroy();
+    this.synthesis?.destroy();
     this.removeCacheFiles();
     this.removeAllListeners();
     super.destroy();

--- a/lib/creator.js
+++ b/lib/creator.js
@@ -66,10 +66,6 @@ class FFCreator extends FFCon {
 
     // front-end render
     const view = !useGL ? this.getConf('canvas') : null;
-    // if (!view) {
-    //   // back-end render
-    //   FFmpegUtil = require('./utils/ffmpeg');
-    // }
 
     const app = Pool.get(
       key,
@@ -112,7 +108,7 @@ class FFCreator extends FFCon {
    * @public
    */
   getFFmpeg() {
-    // return FFmpegUtil.getFFmpeg();
+    return FFmpegUtil.getFFmpeg();
   }
 
   /**
@@ -407,7 +403,7 @@ class FFCreator extends FFCon {
    * @public
    */
   static setFFmpegPath(path) {
-    // FFmpegUtil.setFFmpegPath(path);
+    FFmpegUtil.setFFmpegPath(path);
   }
 
   /**
@@ -416,7 +412,7 @@ class FFCreator extends FFCon {
    * @public
    */
   static setFFprobePath(path) {
-    // FFmpegUtil.setFFprobePath(path);
+    FFmpegUtil.setFFprobePath(path);
   }
 }
 

--- a/lib/creator.js
+++ b/lib/creator.js
@@ -17,6 +17,11 @@
  *
  * @class
  */
+
+ try {
+  const FFmpegUtil = require('./utils/ffmpeg');
+} catch (err) {}
+
 const path = require('path');
 const Conf = require('./conf/conf');
 const Pool = require('./core/pool');
@@ -26,7 +31,6 @@ const FFAudio = require('./audio/audio');
 const FFLogger = require('./utils/logger');
 const forEach = require('lodash/forEach');
 const Renderer = require('./core/renderer');
-const FFmpegUtil = require('./utils/ffmpeg');
 const Effects = require('./animate/effects');
 const { Application, Loader, settings, destroyAndCleanAllCache } = require('inkpaint');
 
@@ -60,6 +64,13 @@ class FFCreator extends FFCon {
     const key = `${this.type}_${render}`;
     settings.PRECISION_FRAGMENT = `${clarity}p`;
 
+    // front-end render
+    const view = !useGL ? this.getConf('canvas') : null;
+    // if (!view) {
+    //   // back-end render
+    //   FFmpegUtil = require('./utils/ffmpeg');
+    // }
+
     const app = Pool.get(
       key,
       () =>
@@ -67,6 +78,7 @@ class FFCreator extends FFCon {
           backgroundColor: 0x000000,
           useGL,
           antialias,
+          view,
         }),
     );
     app.renderer.resize(width, height);
@@ -100,7 +112,7 @@ class FFCreator extends FFCon {
    * @public
    */
   getFFmpeg() {
-    return FFmpegUtil.getFFmpeg();
+    // return FFmpegUtil.getFFmpeg();
   }
 
   /**
@@ -271,6 +283,28 @@ class FFCreator extends FFCon {
   }
 
   /**
+   * Start video play
+   * @public
+   */
+  async play(playRate=1, callback) {
+    this.renderer.play(playRate, callback);
+  }
+
+  /**
+   * Pause video play
+   * @public
+   */
+  async pause() {
+    this.renderer.pause();
+  }
+
+  async jumpTo(timeInMs) {
+    const time = Number(timeInMs);
+    if (isNaN(time) || time < 0) throw new Error("jump to invalid time", timeInMs);
+    this.renderer.jumpTo(time);
+  }
+
+  /**
    * Register to Renderer listen for events
    * @private
    */
@@ -373,7 +407,7 @@ class FFCreator extends FFCon {
    * @public
    */
   static setFFmpegPath(path) {
-    FFmpegUtil.setFFmpegPath(path);
+    // FFmpegUtil.setFFmpegPath(path);
   }
 
   /**
@@ -382,7 +416,7 @@ class FFCreator extends FFCon {
    * @public
    */
   static setFFprobePath(path) {
-    FFmpegUtil.setFFprobePath(path);
+    // FFmpegUtil.setFFprobePath(path);
   }
 }
 

--- a/lib/event/eventer.js
+++ b/lib/event/eventer.js
@@ -39,6 +39,7 @@ class FFEventer extends EventEmitter {
     const event = new FFEvent();
     event.pos = pos;
     event.error = Utils.getErrStack(error);
+    console.log(pos, error);
     this.emit('error', event);
   }
 

--- a/lib/node/chart.js
+++ b/lib/node/chart.js
@@ -150,7 +150,7 @@ class FFChart extends FFImage {
   echartsUpdate(chart, time, delta) {
     const animation = chart._zr.animation;
     if (animation._running && !animation._paused) {
-      animation.update();
+      animation.update(false, time, delta);
     }
   }
 
@@ -158,9 +158,7 @@ class FFChart extends FFImage {
     const animation = chart._zr.animation;
 
     animation._startLoop = () => (animation._running = true);
-    animation.update = function(notTriggerFrameAndStageUpdate) {
-      const time = TimelineUpdate.time;
-      const delta = TimelineUpdate.delta;
+    animation.update = function(notTriggerFrameAndStageUpdate, time, delta) {
       let clip = this._clipsHead;
 
       while (clip) {

--- a/lib/node/gif.js
+++ b/lib/node/gif.js
@@ -11,13 +11,17 @@
  *
  * @class
  */
+
+try {
+  const FS = require('../utils/fs');
+  const probe = require('ffmpeg-probe');
+  const FFmpegUtil = require('../utils/ffmpeg');
+} catch (err) {}
+
 const path = require('path');
-const FS = require('../utils/fs');
 const FFImage = require('./image');
-const probe = require('ffmpeg-probe');
 const { Sprite, Texture } = require('inkpaint');
 const FFLogger = require('../utils/logger');
-const FFmpegUtil = require('../utils/ffmpeg');
 const Materials = require('../utils/materials');
 const TimelineUpdate = require('../timeline/update');
 
@@ -166,7 +170,8 @@ class FFGifImage extends FFImage {
    * Functions for drawing images
    * @private
    */
-  drawing() {
+  drawing(time) {
+    //todo: jump to time
     const texture = this.materials.getFrame(this.frameIndex);
     this.display.updateBaseTexture(texture, true);
     this.nextFrame();

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -209,6 +209,16 @@ class FFNode extends FFBase {
     return this.animations.getDelayTime() / 1000;
   }
 
+  getDuration() {
+    return Math.min(this.duration, this.getDurationTime());
+  }
+
+  lifetime() {
+    const start = this.conf.start || 0;
+    const end = start + this.getDuration();
+    return { start, end };
+  }
+
   getDurationTime() {
     return this.animations.getDurationTime() / 1000;
   }

--- a/lib/node/scene.js
+++ b/lib/node/scene.js
@@ -110,12 +110,16 @@ class FFScene extends FFCon {
    * @return {number} stay time of the scene
    * @public
    */
-  getRealDuration(noRransition = true) {
+  getRealDuration(noTransition = true) {
     if (!this.transition) return this.duration;
 
     let transition = 0;
-    if (noRransition) transition = this.transition.duration;
+    if (noTransition) transition = this.transition.duration;
     return Math.max(0, this.duration - transition);
+  }
+
+  getDuration() {
+    return this.duration;
   }
 
   getFile() {
@@ -135,14 +139,32 @@ class FFScene extends FFCon {
     background.height = height;
   }
 
+  showing() {
+    return this.started;
+  }
+
   /**
    * Start rendering
    * @public
    */
   start() {
+    console.log('scene.start', {id:this.id, start:this.startTime, end:this.endTime});
+    this.started = true;
+    this.parent.addDisplayChild(this);
     super.start();
     this.resizeBackground();
     forEach(this.children, child => child.start());
+  }
+
+  /**
+   * End rendering
+   * @public
+   */
+  end() {
+    console.log('scene.end', {id:this.id, start:this.startTime, end:this.endTime});
+    this.started = false;
+    this.parent.removeDisplayChild(this);
+    forEach(this.children, child => child.end && child.end());
   }
 
   /**

--- a/lib/node/subtitle.js
+++ b/lib/node/subtitle.js
@@ -11,8 +11,11 @@
  *
  * @class
  */
+
+try {
+  const probe = require('ffmpeg-probe');
+} catch (err) {}
 const FFNode = require('./node');
-const probe = require('ffmpeg-probe');
 const forEach = require('lodash/forEach');
 const FFTween = require('../animate/tween');
 const DateUtil = require('../utils/date');
@@ -214,6 +217,7 @@ class FFSubtitle extends FFNode {
   }
 
   drawing(time, delta) {
+    //todo: jump to time
     this.time += delta;
     if (this.time < this.startTime) return;
 

--- a/lib/node/video.js
+++ b/lib/node/video.js
@@ -16,15 +16,19 @@
  *
  * @class
  */
+
+try {
+  const FS = require('../utils/fs');
+  const probe = require('ffmpeg-probe');
+  const FFmpegUtil = require('../utils/ffmpeg');
+} catch (err) {}
+
 const path = require('path');
 const min = require('lodash/min');
-const FS = require('../utils/fs');
 const FFImage = require('./image');
-const probe = require('ffmpeg-probe');
 const FFAudio = require('../audio/audio');
 const DateUtil = require('../utils/date');
 const FFLogger = require('../utils/logger');
-const FFmpegUtil = require('../utils/ffmpeg');
 const Materials = require('../utils/materials');
 const TimelineUpdate = require('../timeline/update');
 const { Sprite, Texture, BaseTexture } = require('inkpaint');
@@ -36,12 +40,10 @@ class FFVideo extends FFImage {
     if (!conf.width)
       FFLogger.error({ pos: 'FFVideo', error: 'This component must enter the width!' });
 
-    this.acommand = FFmpegUtil.createCommand();
-    this.vcommand = FFmpegUtil.createCommand();
-
     this.materials = new Materials();
     this.index = 0;
     this.frameIndex = 0;
+    this.currentTime = 0;
     this.startTime = DEFAULT_TIME; //"00:00:15"
     this.endTime = DEFAULT_TIME; //"00:00:15"
     this.codec = null;
@@ -50,7 +52,6 @@ class FFVideo extends FFImage {
     this.clarity = conf.qscale || conf.clarity || 2;
     this.audio = conf.audio === undefined ? true : conf.audio;
     this.loop = conf.loop === undefined ? false : conf.loop;
-    this.voImageExtra = conf.voImageExtra === undefined ? 'jpg' : conf.voImageExtra;
     this.setDuration(conf.ss, conf.to);
   }
 
@@ -62,6 +63,10 @@ class FFVideo extends FFImage {
   getWH() {
     const { width = 50, height = 50 } = this.conf;
     return [width, height];
+  }
+
+  getDuration() {
+    return DateUtil.hmsToSeconds(this.endTime) - DateUtil.hmsToSeconds(this.startTime);
   }
 
   /**
@@ -145,15 +150,26 @@ class FFVideo extends FFImage {
    * @public
    */
   async preProcessing() {
-    try {
-      const info = await this.getVideoInfo();
-      this.materials.info = info;
-    } catch (e) {}
+    this.fontendRender = this.rootConf('canvas');
+    if (!this.fontendRender) {
+      //back-end render
+      this.acommand = FFmpegUtil.createCommand();
+      this.vcommand = FFmpegUtil.createCommand();
+
+      try {
+        const info = await this.getVideoInfo();
+        this.materials.info = info;
+      } catch (e) {}
+
+      if (this.audio) await this.extractAudio();
+      await this.extractVideo();
+      this.addAudioToScene();
+    } else {
+      const canvas = await this.materials.initCanvas(this.getPath());
+      this.display.attr({ texture: Texture.fromCanvas(canvas) });
+    }
 
     this.resetDurationTime();
-    if (this.audio) await this.extractAudio();
-    await this.extractVideo();
-    this.addAudioToScene();
   }
 
   /**
@@ -161,9 +177,19 @@ class FFVideo extends FFImage {
    * @private
    */
   start() {
-    this.drawCoverImage();
+    if (this.started) return;
+    this.started = true; // lock for once
+    if (!this.fontendRender) this.drawCoverImage();
     this.animations.start();
     this.addTimelineCallback();
+  }
+
+  /**
+   * Pause rendering by scene over
+   * @private
+   */
+  end() {
+    this.materials && this.materials.pause();
   }
 
   /**
@@ -214,10 +240,45 @@ class FFVideo extends FFImage {
    * Functions for drawing images
    * @private
    */
-  drawing() {
-    const texture = this.materials.getFrame(this.frameIndex);
-    this.display.updateBaseTexture(texture, this.useCache);
-    this.nextFrame();
+  async drawing(timeInMs = 0, nextDeltaInMS = 0) {
+    if (!this.parent.started) return this.materials.pause();
+    const lifetime = this.lifetime();
+    // timeInMs 是绝对时间，需要先相对parent求相对时间 sceneTime
+    const sceneTime = (timeInMs / 1000) - this.parent.startTime;
+    if (sceneTime < lifetime.start || sceneTime >= lifetime.end) {
+      // 越界了，暂停
+      return this.materials.pause();
+    }
+
+    // currentTime是当前素材的时间
+    this.currentTime = sceneTime - lifetime.start;
+    const duration = this.getDuration();
+    while (this.loop && this.currentTime >= duration) {
+      this.currentTime = Math.max(0.0, this.currentTime - duration);
+    }
+
+    //todo: support speed
+
+    const ss = (this.startTime === DEFAULT_TIME ? 0 : DateUtil.hmsToSeconds(this.startTime));
+    // console.log('video drawing', {id:this.id, timeInMs, nextDeltaInMS, ss, tt: this.currentTime, st:this.startTime, et:this.endTime, pst: this.parent.startTime});
+    let texture;
+    if (this.fontendRender) {
+      // this.materials.playing = (nextDeltaInMS > 0);
+      if (!nextDeltaInMS) this.materials.pause(); // 视频停止
+      texture = this.materials.getFrameByTime(this.currentTime + ss);
+    } else {
+      // 因为预处理的时候已经ssto了，所以烧制的时候不需要再偏移st了
+      texture = this.materials.getFrame((this.currentTime * this.materials.fps) >> 0);
+      this.display.updateBaseTexture(texture, this.useCache);
+    }
+
+    if (nextDeltaInMS) {
+      const nextTime = this.currentTime + (nextDeltaInMS / 1000);
+      // console.log('nextTime', {nextTime, duration})
+      this.materials.prepare(nextTime >= duration ? 0.0 : nextTime + ss);
+    }
+
+    return texture;
   }
 
   /**
@@ -312,6 +373,7 @@ class FFVideo extends FFImage {
       let times = this.endTime === DEFAULT_TIME ? [] : ['-ss', this.startTime, '-to', this.endTime];
       opts = opts.concat(times);
 
+      this.materials.fps = fps;
       this.materials.path = this.getVOutput();
       this.vcommand.addInput(this.getPath());
       this.vcommand.inputOptions(this.codec ? ['-c:v', this.codec] : []);
@@ -358,8 +420,9 @@ class FFVideo extends FFImage {
   destroy() {
     TimelineUpdate.removeFrameCallback(this.drawing);
     this.materials.destroy();
-    FFmpegUtil.destroy(this.acommand);
-    FFmpegUtil.destroy(this.vcommand);
+    this.acommand && FFmpegUtil.destroy(this.acommand);
+    this.vcommand && FFmpegUtil.destroy(this.vcommand);
+    this.fontendRender = null;
     super.destroy();
   }
 }

--- a/lib/node/video.js
+++ b/lib/node/video.js
@@ -51,6 +51,7 @@ class FFVideo extends FFImage {
     this.clarity = conf.qscale || conf.clarity || 2;
     this.audio = conf.audio === undefined ? true : conf.audio;
     this.loop = conf.loop === undefined ? false : conf.loop;
+    this.voImageExtra = conf.voImageExtra === undefined ? 'jpg' : conf.voImageExtra;
     this.setDuration(conf.ss, conf.to);
   }
 

--- a/lib/node/video.js
+++ b/lib/node/video.js
@@ -19,7 +19,6 @@
 
 try {
   const FS = require('../utils/fs');
-  const probe = require('ffmpeg-probe');
   const FFmpegUtil = require('../utils/ffmpeg');
 } catch (err) {}
 
@@ -63,10 +62,6 @@ class FFVideo extends FFImage {
   getWH() {
     const { width = 50, height = 50 } = this.conf;
     return [width, height];
-  }
-
-  getDuration() {
-    return DateUtil.hmsToSeconds(this.endTime) - DateUtil.hmsToSeconds(this.startTime);
   }
 
   /**
@@ -150,26 +145,24 @@ class FFVideo extends FFImage {
    * @public
    */
   async preProcessing() {
-    this.fontendRender = this.rootConf('canvas');
-    if (!this.fontendRender) {
-      //back-end render
+    this.backendRender = !this.rootConf('canvas');
+    const material = this.materials;
+    const mode = this.backendRender ? material.MODE_BACKEND : material.MODE_FRONTEND;
+    material.init(this.getPath(), mode);
+    await material.prepareInfo();
+    this.resetDurationTime();
+
+    if (this.backendRender) {
+      // back-end render
       this.acommand = FFmpegUtil.createCommand();
       this.vcommand = FFmpegUtil.createCommand();
-
-      try {
-        const info = await this.getVideoInfo();
-        this.materials.info = info;
-      } catch (e) {}
-
       if (this.audio) await this.extractAudio();
       await this.extractVideo();
       this.addAudioToScene();
     } else {
-      const canvas = await this.materials.initCanvas(this.getPath());
-      this.display.attr({ texture: Texture.fromCanvas(canvas) });
+      // front-end render: display -> canvas
+      this.display.attr({ texture: Texture.fromCanvas(material.canvas) });
     }
-
-    this.resetDurationTime();
   }
 
   /**
@@ -179,7 +172,7 @@ class FFVideo extends FFImage {
   start() {
     if (this.started) return;
     this.started = true; // lock for once
-    if (!this.fontendRender) this.drawCoverImage();
+    if (this.backendRender) this.drawCoverImage();
     this.animations.start();
     this.addTimelineCallback();
   }
@@ -236,6 +229,11 @@ class FFVideo extends FFImage {
     });
   }
 
+  getDuration() {
+    return DateUtil.hmsToSeconds(this.endTime) - DateUtil.hmsToSeconds(this.startTime);
+  }
+
+
   /**
    * Functions for drawing images
    * @private
@@ -247,6 +245,7 @@ class FFVideo extends FFImage {
     const sceneTime = (timeInMs / 1000) - this.parent.startTime;
     if (sceneTime < lifetime.start || sceneTime >= lifetime.end) {
       // 越界了，暂停
+      console.log('越界了，暂停', {sceneTime, lifetime});
       return this.materials.pause();
     }
 
@@ -262,14 +261,13 @@ class FFVideo extends FFImage {
     const ss = (this.startTime === DEFAULT_TIME ? 0 : DateUtil.hmsToSeconds(this.startTime));
     // console.log('video drawing', {id:this.id, timeInMs, nextDeltaInMS, ss, tt: this.currentTime, st:this.startTime, et:this.endTime, pst: this.parent.startTime});
     let texture;
-    if (this.fontendRender) {
-      // this.materials.playing = (nextDeltaInMS > 0);
-      if (!nextDeltaInMS) this.materials.pause(); // 视频停止
-      texture = this.materials.getFrameByTime(this.currentTime + ss);
-    } else {
+    if (this.backendRender) {
       // 因为预处理的时候已经ssto了，所以烧制的时候不需要再偏移st了
       texture = this.materials.getFrame((this.currentTime * this.materials.fps) >> 0);
       this.display.updateBaseTexture(texture, this.useCache);
+    } else {
+      if (!nextDeltaInMS) this.materials.pause(); // 视频停止
+      texture = this.materials.getFrameByTime(this.currentTime + ss);
     }
 
     if (nextDeltaInMS) {
@@ -399,10 +397,6 @@ class FFVideo extends FFImage {
         });
       this.vcommand.run();
     });
-  }
-
-  async getVideoInfo() {
-    return await probe(this.getPath());
   }
 
   getVOutput() {

--- a/lib/node/videos.js
+++ b/lib/node/videos.js
@@ -16,12 +16,15 @@
  *
  * @class
  */
+
+try {
+  const FS = require('../utils/fs');
+  const FFmpegUtil = require('../utils/ffmpeg');
+} catch (err) {}
 const path = require('path');
-const FS = require('../utils/fs');
 const FFVideo = require('./video');
 const forEach = require('lodash/forEach');
 const DateUtil = require('../utils/date');
-const FFmpegUtil = require('../utils/ffmpeg');
 
 class FFVideoAlbum extends FFVideo {
   constructor(conf = { list: [] }) {

--- a/lib/timeline/timeline.js
+++ b/lib/timeline/timeline.js
@@ -20,6 +20,7 @@ class Timeline {
   constructor(fps) {
     this.fps = fps;
     this.frame = 0;
+    this.frameInFloat = 0.0;
     this.duration = 0;
     this.framesNum = 0;
     this.frameData = new FrameData();
@@ -84,6 +85,10 @@ class Timeline {
       sceneEnd = point;
       scenes.push({ sceneStart, sceneEnd });
 
+      // add calculated startTime/endTime to scene
+      scene.startTime = sceneStart / this.fps;
+      scene.endTime = sceneEnd / this.fps;
+
       // set this cache variable
       preTrans = trans;
       this.framesNum = point;
@@ -134,6 +139,7 @@ class Timeline {
       }
     }
 
+    // console.log('timeline.getFrameData', {frame, over: frameData.sceneOver, end: frameData.sceneEnd});
     // set the current scenesIndex and type
     for (let i = 0; i < segments.length; i++) {
       const { start, end, total, type, scenesIndex } = segments[i];
@@ -176,12 +182,27 @@ class Timeline {
    * update the next frameData
    * @public
    */
-  nextFrame() {
+  nextFrame(playRate) {
+    if (playRate <= 0) return;
     const { fps } = this;
     if (!this.isOver()) {
-      this.frame++;
-      TimelineUpdate.update(fps);
+      const deltaFrame = playRate;
+      this.frameInFloat += deltaFrame;
+      this.frame = this.frameInFloat >> 0;
+      // console.log("timeline.nextFrame", {f:this.frame, deltaFrame});
+      TimelineUpdate.update(playRate * (1000 / fps));
     }
+  }
+
+  async pause() {
+    return await TimelineUpdate.update(0);
+  }
+
+  async jumpTo(timeInMs) {
+    const { fps } = this;
+    this.frameInFloat = ((timeInMs / 1000) * fps);
+    this.frame = this.frameInFloat >> 0;
+    return await TimelineUpdate.update(0, timeInMs);
   }
 
   setFps(fps) {
@@ -196,6 +217,7 @@ class Timeline {
     this.scenes.length = 0;
     this.segments.length = 0;
     this.frameData = null;
+    TimelineUpdate.destroy();
   }
 }
 

--- a/lib/timeline/update.js
+++ b/lib/timeline/update.js
@@ -10,33 +10,33 @@
  * @class
  */
 const forEach = require('lodash/forEach');
-const TWEEN = require('@tweenjs/tween.js');
+const TWEEN = require('@tweenjs/tween.js/dist/tween.umd');
 
-TWEEN.now = () => new Date().getTime();
+function resetTween() {
+  TWEEN.now = () => 1; // new Date().getTime()
+}
 
 const TimelineUpdate = {
-  delta: 0,
   time: 0,
   cbs: [],
 
   /**
    * TimelineUpdate update function
-   * @param {number} fps - Frame rate
+   * @param {number} delta - delta time
+   * @param {number} timeInMs - Jump to time (ms)
    * @public
    */
-  update(fps = 60) {
-    const delta = (1000 / fps) >> 0;
-
+  async update(delta = 0, timeInMs = -1) {
     if (!this.time) {
-      this.time = TWEEN.now();
+      this.time = timeInMs >= 0 ? timeInMs : TWEEN.now();
       TWEEN.now = () => this.time;
     } else {
-      this.time += delta;
+      this.time = timeInMs >= 0 ? timeInMs : this.time + delta;
     }
 
+    // console.log('update', {ttt: this.time, timeInMs, delta, cbs:this.cbs.length});
     TWEEN.update(this.time);
-    forEach(this.cbs, cb => cb(this.time, delta));
-    this.delta = delta;
+    return Promise.all(this.cbs.map(cb => cb(this.time, delta)));
   },
 
   /**
@@ -60,6 +60,13 @@ const TimelineUpdate = {
     const index = this.cbs.indexOf(callback);
     if (index > -1) this.cbs.splice(index, 1);
   },
+
+  destroy() {
+    this.cbs = [];
+    this.time = 0;
+    resetTween();
+  }
 };
 
+resetTween();
 module.exports = TimelineUpdate;

--- a/lib/utils/canvas.js
+++ b/lib/utils/canvas.js
@@ -9,7 +9,10 @@
  *
  * @object
  */
-const FS = require('./fs');
+
+try {
+  const FS = require('../utils/fs');
+} catch (err) {}
 const Utils = require('./utils');
 const { createCanvas, createImageData, registerFont } = require('inkpaint');
 
@@ -58,6 +61,10 @@ const CanvasUtil = {
       case 'jpg':
       case 'jpeg':
         buffer = canvas.toBuffer('image/jpeg', { quality: quality / 100 });
+        break;
+
+      case 'canvas':
+        buffer = canvas;
         break;
 
       default:

--- a/lib/utils/gl.js
+++ b/lib/utils/gl.js
@@ -13,7 +13,7 @@ const util = require('util');
 const ndarray = require('ndarray');
 const getPixels = require('get-pixels');
 
-const getPixelsFunc = util.promisify(getPixels);
+// const getPixelsFunc = util.promisify(getPixels);
 
 const GLUtil = {
   byteArray: null,
@@ -38,7 +38,8 @@ const GLUtil = {
     if (type === 'raw') {
       return ndarray(data, [width, height, 4], [4, width * 4, 1]);
     } else {
-      return await getPixelsFunc(data, `image/${type}`);
+      return getPixels(data, `image/${type}`);
+      // return await getPixelsFunc(data, `image/${type}`);
     }
   },
 };

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -10,7 +10,12 @@
  *
  * @object
  */
-const colors = require('colors');
+try {
+  const colors = require('colors');
+} catch (err) {
+  const colors = null;
+}
+
 const Utils = require('./utils');
 
 const PRE = '[FF]';
@@ -31,7 +36,7 @@ const FFLogger = {
     pos = pos ? `${pos} ` : '';
 
     const str = `${PRE} ${pos}${msg}`;
-    this.enable && console.log(colors.green(str));
+    this.enable && console.log(colors ? colors.green(str) : str);
     this.hooks['info'] && this.hooks['info'](str);
   },
 
@@ -45,7 +50,7 @@ const FFLogger = {
     pos = pos ? `${pos} ` : '';
 
     const str = `${PRE} ${pos}${msg}`;
-    this.enable && console.log(colors.blue(str));
+    this.enable && console.log(colors ? colors.blue(str) : str);
     this.hooks['log'] && this.hooks['log'](str);
   },
 
@@ -60,7 +65,7 @@ const FFLogger = {
     error = Utils.getErrStack(error);
 
     const str = `${PRE} ${pos}${msg}${error}`;
-    console.error(colors.red(str));
+    console.error(colors ? colors.red(str) : str);
     this.hooks['error'] && this.hooks['error'](str);
   },
 

--- a/lib/utils/materials.js
+++ b/lib/utils/materials.js
@@ -14,7 +14,15 @@
 const DateUtil = require('./date');
 const { Rectangle } = require('inkpaint');
 
+try {
+  const probe = require('ffmpeg-probe');
+  const FFmpegUtil = require('../utils/ffmpeg');
+} catch (err) {}
+
 class Materials {
+  static MODE_FRONTEND = 'mfe';
+  static MODE_BACKEND = 'mbe';
+
   constructor() {
     this.info = null;
     this.fps = 30;
@@ -37,15 +45,15 @@ class Materials {
     // console.log('prepare play', {pt:this.prepareTime, tt:this.time, delta, path:this.path});
     if (delta && !this.playing) {
       // todo: calc playbackRate by delta & adjust err
-      this.element.playbackRate = 1;
-      this.element.play();
+      this.$video.playbackRate = 1;
+      this.$video.play();
       this.playing = true;
     }
   }
 
   pause() {
     if (!this.playing) return;
-    this.element && this.element.pause();
+    this.$video && this.$video.pause();
     this.playing = false;
   }
 
@@ -57,14 +65,14 @@ class Materials {
       // console.log('ma.getFrameByTime', this.time, this.prepareTime, this.playing);
       if (!this.playing || this.time.toFixed(3) != this.prepareTime.toFixed(3)) {
         //seek to time
-        this.element.currentTime = this.time;
-        this.element.addEventListener('canplay', e => {
-          console.log('canplay', this.element.currentTime, this.path);
-          this.canvasContext.drawImage(this.element, 0, 0, width, height);
+        this.$video.currentTime = this.time;
+        this.$video.addEventListener('canplay', e => {
+          console.log('canplay', this.$video.currentTime, this.path);
+          this.canvasContext.drawImage(this.$video, 0, 0, width, height);
           resolve(this.canvas);
         }, { once: true });
       } else {
-        this.canvasContext.drawImage(this.element, 0, 0, width, height);
+        this.canvasContext.drawImage(this.$video, 0, 0, width, height);
         resolve(this.canvas);
       }
     });
@@ -85,28 +93,44 @@ class Materials {
     });
   }
 
-  async initCanvas(path) {
-    this.path = await this.getResource(path);
-    console.log('res', this.path);
-
+  init(src, mode) {
+    if (this.inited) return;
     this.inited = true;
+    this.path = src;
+    if (mode == this.MODE_FRONTEND) this.initCanvas();
+  }
+
+  initCanvas() {
     this.canvas = document.createElement('canvas');
     this.canvas.width = 600;
     this.canvas.height = 300;
     this.canvasContext = this.canvas.getContext('2d');
 
-    this.element = document.createElement('video');
-    this.element.crossOrigin = 'Anonymous';
-    this.element.style = "background:#000";
-    this.element.src = this.path;
-    this.element.width = 300;
-    this.element.height = 300;
-    this.element.controls = "controls";
-    // console.log('initCanvas path', this.path);
+    this.$video = document.createElement('video');
+    this.$video.crossOrigin = 'Anonymous';
+    this.$video.style = "background:#000";
+    this.$video.src = this.path;
+    this.$video.width = 300;
+    this.$video.height = 300;
+    this.$video.controls = "controls";
 
     const testDom = document.getElementById('mira-testv');
-    if (testDom) testDom.appendChild(this.element);
+    if (testDom) testDom.appendChild(this.$video);
     return this.canvas;
+  }
+
+  async prepareInfo() {
+    this.info = await (this.$video ? this.feProbe() : probe(this.path));
+  }
+
+  async feProbe() {
+    return new Promise((resolve, reject) => {
+      this.$video.addEventListener('loadedmetadata', e => {
+        const { duration, videoWidth, videoHeight } = this.$video;
+        resolve({ width: videoWidth, height: videoHeight, duration });
+      });
+      this.$video.addEventListener('error', e => reject());
+    });
   }
 
   /**
@@ -197,12 +221,12 @@ class Materials {
   }
 
   destroy() {
-    if (this.element?.parentElement) this.element.remove();
+    if (this.$video?.parentElement) this.$video.remove();
     this.canvas = null;
     this.canvasContext = null;
     this.inited = false;
     this.playing = false;
-    this.element = null;
+    this.$video = null;
     this.info = null;
     this.path = '';
     this.length = 0;

--- a/lib/utils/materials.js
+++ b/lib/utils/materials.js
@@ -17,11 +17,96 @@ const { Rectangle } = require('inkpaint');
 class Materials {
   constructor() {
     this.info = null;
+    this.fps = 30;
     this.path = '';
     this.apath = '';
     this.start = 0;
     this.end = 0;
     this.length = 0;
+
+    // for player
+    this.time = 0;
+    this.prepareTime = 0;
+    this.inited = false;
+    this.playing = false;
+  }
+
+  prepare(time) {
+    this.prepareTime = time;
+    const delta = this.prepareTime - this.time;
+    // console.log('prepare play', {pt:this.prepareTime, tt:this.time, delta, path:this.path});
+    if (delta && !this.playing) {
+      // todo: calc playbackRate by delta & adjust err
+      this.element.playbackRate = 1;
+      this.element.play();
+      this.playing = true;
+    }
+  }
+
+  pause() {
+    if (!this.playing) return;
+    this.element && this.element.pause();
+    this.playing = false;
+  }
+
+  async getFrameByTime(time) {
+    this.time = time;
+    return new Promise((resolve, reject) => {
+      const width = 600;
+      const height = 300;
+      // console.log('ma.getFrameByTime', this.time, this.prepareTime, this.playing);
+      if (!this.playing || this.time.toFixed(3) != this.prepareTime.toFixed(3)) {
+        //seek to time
+        this.element.currentTime = this.time;
+        this.element.addEventListener('canplay', e => {
+          console.log('canplay', this.element.currentTime, this.path);
+          this.canvasContext.drawImage(this.element, 0, 0, width, height);
+          resolve(this.canvas);
+        }, { once: true });
+      } else {
+        this.canvasContext.drawImage(this.element, 0, 0, width, height);
+        resolve(this.canvas);
+      }
+    });
+  }
+
+  async getResource(url) {
+    if (url.startsWith('blob:') || 1) return url;
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.responseType = 'blob';
+      xhr.open("GET", url);
+      xhr.onload = (e) => resolve(URL.createObjectURL(xhr.response));
+      xhr.onerror = (e) => reject(xhr.responseText);
+      xhr.onprogress = (e) => {
+        console.log('preloading', url, (100 * e.loaded / e.total).toFixed(1) + '%');
+      };
+      xhr.send();
+    });
+  }
+
+  async initCanvas(path) {
+    this.path = await this.getResource(path);
+    console.log('res', this.path);
+
+    this.inited = true;
+    this.canvas = document.createElement('canvas');
+    this.canvas.width = 600;
+    this.canvas.height = 300;
+    this.canvasContext = this.canvas.getContext('2d');
+
+    this.element = document.createElement('video');
+    this.element.crossOrigin = 'Anonymous';
+    this.element.style = "background:#000";
+    this.element.src = this.path;
+    this.element.width = 300;
+    this.element.height = 300;
+    this.element.controls = "controls";
+    // console.log('initCanvas path', this.path);
+
+    const testDom = document.getElementById('mira-testv');
+    if (testDom) testDom.appendChild(this.element);
+    return this.canvas;
   }
 
   /**
@@ -112,6 +197,12 @@ class Materials {
   }
 
   destroy() {
+    if (this.element?.parentElement) this.element.remove();
+    this.canvas = null;
+    this.canvasContext = null;
+    this.inited = false;
+    this.playing = false;
+    this.element = null;
     this.info = null;
     this.path = '';
     this.length = 0;


### PR DESCRIPTION
思路：
1. 通过creator附加的canvas参数，绕过FFMPEG等后端烧录的引用，直接渲染给canvas，实现播放。
2. renderer.renderFrame 改为根据 timeline.getFrameData() 中的 scenesIndex 来判断当前哪些scene是应该显示状态，结合scene.showing()来判断当前是否已经符合状态，然后操作scene.start()/scene.end()来加载/移除display
3. timeline.annotate的时候，给每个scene标注上 startTime/endTime，方便scene的children之后在拿到【绝对时间】后，能计算【相对scene的时间】
4. timeline.nextFrame 里从计算【frame】的计数改为【时间】，目的是允许浮点数，方便未来实现速度播放（playRate）
5. 修改TimelineUpdate.update接口传参，改为 (delta = 0, timeInMs = -1) 单位都是时间(ms)，如果delta=0，则是seek时间（非播放状态），如果timeInMs=-1，则是在当前时间轴上往后播放，不做seek。
6. TimelineUpdate.update之后，callback调用每个node的draw方法，也都传入time和delta，实现时间轴上的seek和播放
7. material加上getFrameByTime，用前端方式实现视频的播放到canvas里。