### PR TITLE
fix audio lag

### DIFF
--- a/lib/material/material.js
+++ b/lib/material/material.js
@@ -34,7 +34,7 @@ class Material {
 
   static MAIN_DELAY() {
     if (!Material.MAIN_PLAYER || !Material.MAIN_PLAYER.player().playing
-       || Material.MAIN_PLAYER.parent.constructor.name !== 'FFScene') {
+       || Material.MAIN_PLAYER.parent?.constructor.name !== 'FFScene') {
       Material.MAIN_PLAYER = Material.PLAYER(Material.VIDEOS) || Material.PLAYER(Material.AUDIOS);
     }
     return Material.MAIN_PLAYER ? (Material.MAIN_PLAYER.delay() * 1000) >> 0 : 0;

--- a/lib/material/material.js
+++ b/lib/material/material.js
@@ -33,7 +33,8 @@ class Material {
   static MAIN_PLAYER;
 
   static MAIN_DELAY() {
-    if (!Material.MAIN_PLAYER || !Material.MAIN_PLAYER.player().playing) {
+    if (!Material.MAIN_PLAYER || !Material.MAIN_PLAYER.player().playing
+       || Material.MAIN_PLAYER.parent.constructor.name !== 'FFScene') {
       Material.MAIN_PLAYER = Material.PLAYER(Material.VIDEOS) || Material.PLAYER(Material.AUDIOS);
     }
     return Material.MAIN_PLAYER ? (Material.MAIN_PLAYER.delay() * 1000) >> 0 : 0;


### PR DESCRIPTION
现在是根据顺序找到"主播放源(main player)"，优先级：
1. 视频
2. Scene里面的音频
3. Creator里的音频（多半是BGM）

然后播放的时候用PID算法矫正当前timeline(TWEEN)时间轴和main player一致。
可能出现的问题：
在播放视频的时候（优先级更高）TTS的语音还是会被吞掉