### PR TITLE
node native support rpx

### DIFF
--- a/lib/core/base.js
+++ b/lib/core/base.js
@@ -89,8 +89,11 @@ class FFBase extends FFEventer {
   }
 
   creator() {
-    const root = this.root();
-    if (root.type === 'creator') return root;
+    if (!this._creator) {
+      const root = this.root();
+      if (root.type === 'creator') this._creator = root;
+    }
+    return this._creator;
   }
 
   /**
@@ -101,6 +104,7 @@ class FFBase extends FFEventer {
     super.destroy();
     this.conf = null;
     this.parent = null;
+    this._creator = null;
   }
 }
 

--- a/lib/core/clip.js
+++ b/lib/core/clip.js
@@ -1,10 +1,13 @@
 
 const FFBase = require('./base');
 const { DisplayObject } = require('../../inkpaint/lib/index');
+const { dmap } = require('../utils/utils');
 
 class FFClip extends FFBase {
   constructor(conf = {}) {
     super({ type: 'clip', ...conf });
+    this.canvasWidth = conf.canvasWidth;
+    this.canvasHeight = conf.canvasHeight;
     this.parent = null;
     this.prevSibling = null;
     this.nextSibling = null;
@@ -199,6 +202,57 @@ class FFClip extends FFBase {
       time = Number(time);
     }
     return time < 0 ? parentDuration + time : time;
+  }
+
+  px(data) {
+    const num = Number(data);
+    if (!isNaN(num)) return num;
+    if (typeof(data) === 'object') return dmap(data, x => this.px(x));
+    const [inum, unit] = this.deunit(data);
+    return inum;
+  }
+
+  setConfRpx(key, val) {
+    const prev = this.conf[key];
+    let [inum, unit] = this.deunit(prev);
+    if (!unit) unit = 'rpx'; // todo: 强制rpx
+    this.conf[key] = this.enunit(val, unit);
+  }
+
+  units() {
+    const creator = this.creator();
+    if (creator) {
+      this.canvasWidth = creator.width;
+      this.canvasHeight = creator.height;
+    }
+    return [
+      ['rpx', this.canvasWidth, 360],
+      ['px', 360, 360],
+      ['vw', this.canvasWidth, 100],
+      ['vh', this.canvasHeight, 100]
+    ];
+  }
+
+  enunit(px, unit) {
+    const ut = this.units().filter(ut => ut[0] === unit)[0];
+    if (!ut) return px;
+    return `${(px * ( ut[2] / ut[1])).toFixed(3)}${unit}`;
+  }
+
+  deunit(data) {
+    if (typeof(data) === 'number' || !data) return [data, null];
+    const lower_data = data.toString().toLowerCase().trim();
+    const unit = (input, unit, original, target) => {
+      if (!input.endsWith(unit)) return null;
+      const inum = Number(input.substring(0, input.length - unit.length));
+      return isNaN(inum) ? null : inum * (original / target);
+    }
+
+    for (const ut of this.units()) {
+      const inum = unit(lower_data, ut[0], ut[1], ut[2]);
+      if (inum !== null) return [inum, ut[0]];
+    }
+    return [data, null];
   }
 
   destroy() {

--- a/lib/core/clip.js
+++ b/lib/core/clip.js
@@ -14,8 +14,22 @@ class FFClip extends FFBase {
     this.visible = false;
     this.zIndex = 0;
     this.children = [];
+    this.active = conf.active !== undefined ? !!conf.active : true;
     this.onTime = () => false;
     this.createDisplay();
+  }
+
+  toJson() {
+    const conf = {...this.conf};
+    if (conf.origSrc && conf.src) {
+      // 把cache过的地址还原
+      conf.src = conf.origSrc;
+      delete conf.origSrc;
+    }
+    delete conf.canvasHeight;
+    delete conf.canvasWidth;
+    conf.children = this.children.map(c => c.toJson());
+    return conf;
   }
 
   createDisplay() {
@@ -55,17 +69,20 @@ class FFClip extends FFBase {
 
   disable() {
     if (!this.parent) return;
+    this.active = this.conf.active = false;
     this.hide();
     this.removeTimelineCallback();
   }
 
   enable() {
     if (!this.parent) return;
+    this.active = this.conf.active = true;
     this.onTime(this.creator().currentTime / 1000);
     this.addTimelineCallback();
   }
 
   addTimelineCallback() {
+    if (!this.active) return;
     if (!this._drawing) {
       // this._drawing = this.drawing.bind(this);
       this._drawing = async (timeInMs, nextDeltaInMS) => {

--- a/lib/creator.js
+++ b/lib/creator.js
@@ -325,7 +325,8 @@ class FFCreator extends FFCon {
     let zIndex = 0;
     const walkzIndex = (node) => {
       node.children.map(x => {
-        x.zIndex = x.basezIndex + zIndex++;
+        zIndex += 1;
+        x.zIndex = x.basezIndex + zIndex;
         this.maxzIndex = Math.max(x.zIndex, this.maxzIndex);
         walkzIndex(x);
       });
@@ -467,6 +468,13 @@ class FFCreator extends FFCon {
         height: this.getConf('height'),
       });
     }
+  }
+
+  toJson() {
+    const conf = super.toJson();
+    conf.type = 'canvas';
+    conf.fps = this.getConf('fps');
+    return conf;
   }
 
   async destroy() {

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ const FFCreatorCenter = require('./center/center');
 const TYPES = {
   canvas: FFCreator,
   spine: FFSpine,
-  transition: FFTransition,
+  trans: FFTransition,
   scene: FFScene,
   node: FFNode,
   text: FFText,

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,6 +68,11 @@ const Factory = {
   },
   async fromJson(json, cache, progress) {
     const { type, children = [], ...others } = json;
+    if (type == 'canvas') {
+      // 初始化的时候px计算的依赖
+      others.canvasWidth = others.width;
+      others.canvasHeight = others.height;
+    }
 
     let childNodes = [];
     for (let child of children) {
@@ -76,6 +81,9 @@ const Factory = {
         others[child.type] = this.parseAttribute(child, others[child.type]);
         continue;
       }
+      // 把canvas尺寸先传下去，作为初始化的时候px计算的依赖
+      child.canvasWidth = others.canvasWidth;
+      child.canvasHeight = others.canvasHeight;
       childNodes.push(this.fromJson(child, cache, progress));
     }
     childNodes = await Promise.all(childNodes);

--- a/lib/node/gif.js
+++ b/lib/node/gif.js
@@ -74,6 +74,11 @@ class FFGifImage extends FFImage {
     return { time, loops };
   }
 
+  async getFrameByTime(matTime) {
+    const imgData = await this.material.getFrameByTime(matTime);
+    return this.material.getImage(imgData);
+  }
+
   /**
    * Functions for drawing images
    * @private

--- a/lib/node/image.js
+++ b/lib/node/image.js
@@ -19,6 +19,7 @@ const { isBrowser } = require("browser-or-node");
 class FFImage extends FFNode {
   constructor(conf = { animations: [] }) {
     super({ type: 'image', ...conf });
+    this.canvas = {}; // todo: destory
     if (conf.resetPos || conf.resetXY) this.resetLeftTop();
     if (Array.isArray(conf.frame) && conf.frame.length === 4) {
       this.setFrame(...conf.frame);
@@ -49,6 +50,32 @@ class FFImage extends FFNode {
       h = fh;
     }
     return { x, y, w, h };
+  }
+
+  materialTime(absTime, mabs=false) {
+    return { time: 0, loops: 0 };
+  }
+
+  async getFrameByTime(matTime) {
+    return this.material.canvas;
+  }
+
+  async getPreview(matTime, { width, height, format='jpeg' }={}) {
+    const image = await this.getFrameByTime(matTime);
+    const frame = this.getFrame();
+    width = width || frame.w;
+    height = height || frame.h;
+    const cacheKey = `${width}|${height}`;
+    if (!this.canvas[cacheKey]) {
+      this.canvas[cacheKey] = this.material.initCanvas(width, height);
+    }
+    const canvas = this.canvas[cacheKey];
+    const ctx = canvas.getContext('2d');
+    const scale = Math.max(width / frame.w, height / frame.h);
+    const [vw, vh] = [frame.w * scale, frame.h * scale];
+    ctx.drawImage(image, frame.x, frame.y, frame.w, frame.h, 
+      (width - vw) / 2, (height - vh) / 2, vw, vh);
+    return format === 'canvas' ? canvas : canvas.toDataURL(`image/${format}`);
   }
 
   getObjectPosition() {
@@ -251,6 +278,7 @@ class FFImage extends FFNode {
   destroy() {
     super.destroy();
     this.material.destroy();
+    this.canvas = null;
   }
 }
 

--- a/lib/node/image.js
+++ b/lib/node/image.js
@@ -125,6 +125,8 @@ class FFImage extends FFNode {
 
   fitSize() {
     let { width, height } = this.conf;
+    width = this.px(width);
+    height = this.px(height);
     const src = this.display; // resource
     let w = this.material.width();
     let h = this.material.height();
@@ -159,6 +161,8 @@ class FFImage extends FFNode {
     if (this.frame) this.setScale(this.scale);
     if (fit === 'fill') return; // fill直接拉伸
     let { width, height } = this.conf; // container size with scaled
+    width = this.px(width);
+    height = this.px(height);
     src = src || this.display; // resource
     if (src.scale.x <= 0 || src.scale.y <= 0) return;
     let mw = this.material.width();
@@ -225,8 +229,8 @@ class FFImage extends FFNode {
     const { display } = this;
     const { width, height } = this.conf;
     if (width && height) {
-      display.width = width;
-      display.height = height;
+      display.width = this.px(width);
+      display.height = this.px(height);
     }
   }
 

--- a/lib/node/node.js
+++ b/lib/node/node.js
@@ -100,9 +100,10 @@ class FFNode extends FFClip {
    * @public
    */
   setXY(x = 0, y = 0) {
-    this.display.x = this.conf.x = x;
-    this.display.y = this.conf.y = y;
-    
+    this.display.x = this.px(x);
+    this.display.y = this.px(y);
+    this.setConfRpx('x', this.display.x);
+    this.setConfRpx('y', this.display.y);
   }
 
   /**
@@ -131,8 +132,8 @@ class FFNode extends FFClip {
    * @public
    */
   setSize(width, height) {
-    this.conf.width = width;
-    this.conf.height = height;
+    this.setConfRpx('width', width);
+    this.setConfRpx('height', height);
   }
 
   /**
@@ -152,10 +153,6 @@ class FFNode extends FFClip {
   addBlend(blend = '') {
     const blendMode = BLEND_MODES[blend.toUpperCase()];
     if (blendMode) this.display.blendMode = blendMode;
-  }
-
-  get rpx() {
-    return 360 / this.creator().getWidth();
   }
 
   get rotation() {
@@ -224,7 +221,7 @@ class FFNode extends FFClip {
   getWH() {
     const { width = 0, height = 0 } = this.conf;
     if (width && height) {
-      return [width, height];
+      return this.px([width, height]);
     } else {
       return [this.display.width, this.display.height];
     }
@@ -244,7 +241,7 @@ class FFNode extends FFClip {
 
   fitSize() {
     let { width, height } = this.conf;
-    this.display.attr({ width, height });
+    this.display.attr(this.px({ width, height }));
   }
 
   fitTexture() {

--- a/lib/node/rect.js
+++ b/lib/node/rect.js
@@ -17,7 +17,7 @@ const { createCanvas, Sprite, Texture } = require('../../inkpaint/lib/index');
 
 class FFRect extends FFNode {
   constructor(conf = { rect: '', style: { fontSize: 28 } }) {
-    super({ type: 'rect', ...conf });
+    super({ type: 'div', ...conf });
     const { color = '#044EC5' } = this.conf;
     this.setColor(color);
   }

--- a/lib/node/text.js
+++ b/lib/node/text.js
@@ -29,7 +29,8 @@ class FFText extends FFNode {
    * @private
    */
   createDisplay() {
-    const { text, fontSize = 36, color = '#000000' } = this.conf;
+    let { text, fontSize = 28, color = '#000000' } = this.conf;
+    fontSize = this.px(fontSize);
     this.display = new ProxyObj();
     // this.setAnchor(0.5);
     this.display.text = text;
@@ -127,10 +128,11 @@ class FFText extends FFNode {
   }
 
   setWH(w, h) {
-    const { width, height, fontSize } = this.conf;
+    let { width, height, fontSize } = this.conf;
+    width = this.px(width); height = this.px(height); fontSize = this.px(fontSize);
     if (this.started && width && height && w && h && fontSize) {
       if ((w / width).toFixed(6) === (h / height).toFixed(6)) {
-        this.conf.fontSize = fontSize * (w / width);
+        this.setConfRpx('fontSize', fontSize * (w / width));
       }
     }
     super.setWH(w, h);
@@ -138,12 +140,14 @@ class FFText extends FFNode {
 
   fitSize() {
     let { width, fontSize } = this.conf;
+    width = this.px(width); fontSize = this.px(fontSize);
     this.setStyle({
       fontSize, wordWrapWidth: width,
       wordWrap: true, breakWords: true,
     });
     this.display.updateText(true);
-    this.conf.height = this.display.height; // change as line breaks
+    // change as line breaks
+    this.setConfRpx('height', this.display.height);
   }
 
   /**

--- a/lib/node/video.js
+++ b/lib/node/video.js
@@ -23,7 +23,6 @@ class FFVideo extends FFGifImage {
   constructor(conf) {
     super({ type: 'video', loop: false, audio: true, ...conf });
     this.useCache = false;
-    this.canvas = {}; // todo: destory
   }
 
   /**
@@ -49,21 +48,8 @@ class FFVideo extends FFGifImage {
     return this.material.grantPlay(); // for safari
   }
 
-  async getPreview(videoTime, { width, height, format='jpeg' }={}) {
-    const video = await this.material.seekTo(videoTime);
-    width = width || video.videoWidth;
-    height = height || video.videoHeight;
-    const cacheKey = `${width}|${height}`;
-    if (!this.canvas[cacheKey]) {
-      this.canvas[cacheKey] = this.material.initCanvas(width, height);
-    }
-    const canvas = this.canvas[cacheKey];
-    const ctx = canvas.getContext('2d');
-    const scale = Math.max(width / video.videoWidth, height / video.videoHeight);
-    const [vw, vh] = [video.videoWidth * scale, video.videoHeight * scale];
-    // todo: apply this.frame crop
-    ctx.drawImage(video, (width - vw) / 2, (height - vh) / 2, vw, vh);
-    return format === 'canvas' ? canvas : canvas.toDataURL(`image/${format}`);
+  async getFrameByTime(matTime) {
+    return await this.material.seekTo(matTime);
   }
 
   async prepareMaterial() {

--- a/lib/node/video.js
+++ b/lib/node/video.js
@@ -49,7 +49,7 @@ class FFVideo extends FFGifImage {
     return this.material.grantPlay(); // for safari
   }
 
-  async getFrame(videoTime, { width, height, format='jpeg' }={}) {
+  async getPreview(videoTime, { width, height, format='jpeg' }={}) {
     const video = await this.material.seekTo(videoTime);
     width = width || video.videoWidth;
     height = height || video.videoHeight;
@@ -61,6 +61,7 @@ class FFVideo extends FFGifImage {
     const ctx = canvas.getContext('2d');
     const scale = Math.max(width / video.videoWidth, height / video.videoHeight);
     const [vw, vh] = [video.videoWidth * scale, video.videoHeight * scale];
+    // todo: apply this.frame crop
     ctx.drawImage(video, (width - vw) / 2, (height - vh) / 2, vw, vh);
     return format === 'canvas' ? canvas : canvas.toDataURL(`image/${format}`);
   }

--- a/lib/utils/utils.js
+++ b/lib/utils/utils.js
@@ -50,6 +50,17 @@ const Utils = {
     return Promise.all(res);
   },
 
+  dmap(src, func, keys=[]) {
+    const dst = Array.isArray(src) ? [] : {};
+    const arr = Array.isArray(src) ? src.map((a, i) => [i, a]) : Object.entries(src);
+    for (const [key, value] of arr) {
+      const _keys = [...keys, key];
+      if (typeof value === 'object') dst[key] = DataUtil.dmap(value, func, _keys);
+      else dst[key] = func(value, key, _keys);
+    }
+    return dst;
+  },
+
   /**
    * Generate auto-increment id based on type
    * @param {string} type - type

--- a/lib/utils/xml.js
+++ b/lib/utils/xml.js
@@ -24,21 +24,16 @@ const measure = (data, width, height) => {
     return Array.isArray(arr) ? arr.map(i => measure(i, width, height)) : data;
   }
 
-  const unit = (input, unit, original, target) => {
+  // number with unit
+  const unit = (input, unit) => {
     if (!input.endsWith(unit)) return null;
     const inum = Number(input.substring(0, input.length - unit.length));
-    return isNaN(inum) ? null : inum * (original / target);
+    return isNaN(inum) ? null : inum;
   }
 
-  const units = [
-    ['rpx', width, 360],
-    ['px', 360, 360],
-    ['vw', width, 100],
-    ['vh', height, 100]
-  ];
-  for (let i = 0; i < units.length; i++) {
-    const inum = unit(lower_data, units[i][0], units[i][1], units[i][2]);
-    if (inum !== null) return inum;
+  for (const ut of [ 'rpx', 'px', 'vw', 'vh' ]) {
+    const inum = unit(lower_data, ut);
+    if (inum !== null) return `${inum}${ut}`;
   }
 
   return data;
@@ -76,7 +71,7 @@ module.exports = {
   parseXml: function (xml) {
     const oDOM = oParser.parseFromString(xml, "application/xml");
     if (oDOM.documentElement.nodeName.toLowerCase() == 'miraml') {
-      return parseNode(oDOM.documentElement, measure);
+      return parseNode(oDOM.documentElement);
     }
   }
 };


### PR DESCRIPTION
把原先在parseXML时就要转换px的做法，改到node里自己做。
这样就能实现更改的时候，参考原单位不变再去set。

目前遗留的问题：
1. 宽高自适应的元素，目前未设置的都会被统一改为rpx，但其实应该参考另一半，比如width参考height的单位
2. 目前改了x,y,width,height,fontSize，但可能还有什么遗漏的地方？